### PR TITLE
frature virtualnode output accesslog

### DIFF
--- a/pkg/router/appmesh_v1beta2.go
+++ b/pkg/router/appmesh_v1beta2.go
@@ -125,6 +125,7 @@ func (ar *AppMeshv1beta2Router) reconcileVirtualNode(canary *flaggerv1.Canary, n
 		},
 	}
 
+
 	backends := make([]appmeshv1.Backend, 0)
 	for i := range canary.Spec.Service.Backends {
 		if strings.HasPrefix(canary.Spec.Service.Backends[i], "arn:aws") {


### PR DESCRIPTION
Signed-off-by: wucg <wucg@trip.com>

accesslog is very important for analyzing inbound and outboud traffic,
so we want to configure it by default when creating a virtualNode.